### PR TITLE
Add Steam Username and Password Login Parameters

### DIFF
--- a/multibound2/data/config.cpp
+++ b/multibound2/data/config.cpp
@@ -54,6 +54,7 @@ void MultiBound::Config::load() {
         steamcmdDLRoot = cfg["steamcmdRoot"].toString(steamcmdDLRoot);
 
         steamcmdUpdateSteamMods = cfg["steamcmdUpdateSteamMods"].toBool(steamcmdUpdateSteamMods);
+
         steamUsername = cfg["steamUsername"].toString(steamUsername);
         steamPassword = cfg["steamPassword"].toString(steamPassword);
     }
@@ -76,10 +77,11 @@ void MultiBound::Config::save() {
     cfg["starboundPath"] = starboundPath;
     cfg["instanceRoot"] = instanceRoot;
     cfg["steamcmdRoot"] = steamcmdDLRoot;
-    cfg["steamUsername"] = steamUsername;
-    cfg["steamPassword"] = steamPassword;
 
     cfg["steamcmdUpdateSteamMods"] = steamcmdUpdateSteamMods;
+
+    cfg["steamUsername"] = steamUsername;
+    cfg["steamPassword"] = steamPassword;
 
     QFile f(Util::splicePath(configPath, "/config.json"));
     f.open(QFile::WriteOnly);

--- a/multibound2/data/config.cpp
+++ b/multibound2/data/config.cpp
@@ -18,6 +18,8 @@ QString MultiBound::Config::steamcmdDLRoot;
 QString MultiBound::Config::steamcmdWorkshopRoot;
 QString MultiBound::Config::starboundPath;
 QString MultiBound::Config::starboundRoot;
+QString MultiBound::Config::steamUsername;
+QString MultiBound::Config::steamPassword;
 
 bool MultiBound::Config::steamcmdEnabled = true;
 bool MultiBound::Config::steamcmdUpdateSteamMods = true;
@@ -52,6 +54,8 @@ void MultiBound::Config::load() {
         steamcmdDLRoot = cfg["steamcmdRoot"].toString(steamcmdDLRoot);
 
         steamcmdUpdateSteamMods = cfg["steamcmdUpdateSteamMods"].toBool(steamcmdUpdateSteamMods);
+        steamUsername = cfg["steamUsername"].toString(steamUsername);
+        steamPassword = cfg["steamPassword"].toString(steamPassword);
     }
 
     if (auto d = QDir(instanceRoot); !d.exists()) d.mkpath(".");
@@ -72,6 +76,8 @@ void MultiBound::Config::save() {
     cfg["starboundPath"] = starboundPath;
     cfg["instanceRoot"] = instanceRoot;
     cfg["steamcmdRoot"] = steamcmdDLRoot;
+    cfg["steamUsername"] = steamUsername;
+    cfg["steamPassword"] = steamPassword;
 
     cfg["steamcmdUpdateSteamMods"] = steamcmdUpdateSteamMods;
 

--- a/multibound2/data/config.h
+++ b/multibound2/data/config.h
@@ -13,6 +13,9 @@ namespace MultiBound {
         extern QString workshopRoot;
         extern QString steamcmdDLRoot;
         extern QString steamcmdWorkshopRoot;
+        
+        extern QString steamUsername;
+        extern QString steamPassword;
 
         extern bool steamcmdEnabled;
         extern bool steamcmdUpdateSteamMods;

--- a/multibound2/steamcmd.cpp
+++ b/multibound2/steamcmd.cpp
@@ -116,7 +116,7 @@ void MultiBound::Util::updateMods(MultiBound::Instance* inst) {
     QString wsScript, dlScript;
     QTextStream wss(&wsScript), dls(&dlScript);
 
-    wss << qs("login anonymous\n");
+    wss << qs("login " << Config::steamUsername << " " << Config::steamPassword << "\n");
     if (ws) { // if valid workshop, force proper root in case steamcmd defaults are incorrect
         QDir wsr(Config::workshopRoot);
         for (int i = 0; i < 4; i++) wsr.cdUp();

--- a/multibound2/steamcmd.cpp
+++ b/multibound2/steamcmd.cpp
@@ -116,7 +116,7 @@ void MultiBound::Util::updateMods(MultiBound::Instance* inst) {
     QString wsScript, dlScript;
     QTextStream wss(&wsScript), dls(&dlScript);
 
-    wss << qs("login " << Config::steamUsername << " " << Config::steamPassword << "\n");
+    wss << qs("login ") << Config::steamUsername << qs(" ") << Config::steamPassword << qs("\n");
     if (ws) { // if valid workshop, force proper root in case steamcmd defaults are incorrect
         QDir wsr(Config::workshopRoot);
         for (int i = 0; i < 4; i++) wsr.cdUp();


### PR DESCRIPTION
Fixes issue #5

I am still a bit rusty on C++ so I am not sure if I did the changes correctly. But I have added a Username and Password config variables, because SteamCMD cannot download mods without being logged into an account as #5 describes.

I know this isn't the most secure method, but it'll have to do for now, if you want to make a more secure method, like a dialog box that pops up and asks for a password that would be a lot better.

Also, I would have just did the changes and built it myself, but I am completely lost on how to build from source on Windows.